### PR TITLE
Appointment payment logic

### DIFF
--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -28,6 +28,14 @@ class ConsultationsController < ApplicationController
   def new_appointment
     @consultation = Consultation.new
     @client = current_user.client
+    @lawyer = Lawyer.find(params[:lawyer_id])
+    should_the_lawyer_give_a_free_consult?
+    @ask_for_credit_card = true
+    if !@client.stripe_id.nil?
+      @ask_for_credit_card = false
+    elsif should_the_lawyer_give_a_free_consult?
+      @ask_for_credit_card = false
+    end
   end
 
   def create_new_appointment
@@ -104,6 +112,12 @@ class ConsultationsController < ApplicationController
   end
 
   private
+
+  def should_the_lawyer_give_a_free_consult?
+    consultations = @lawyer.consultations.where(client_id: @client.id)
+    valid_consultations = consultations.where("duration > 0")
+    (valid_consultations.count == 0 && @lawyer.is_first_consultation_free)
+  end
 
   def start_consultation
     @consultation.start_time = Time.new if @consultation.start_time.nil?

--- a/app/views/consultations/new_appointment.html.erb
+++ b/app/views/consultations/new_appointment.html.erb
@@ -6,7 +6,7 @@
 
       <%= simple_form_for(@consultation, :method => :post, :url => new_appointment_path) do |f| %>
       <%= text_field_tag :appointment_time, nil, id: "appointment_time_input"%>
-      <% if @client.stripe_id.nil? %>
+      <% if @ask_for_credit_card %>
       <script
       src="https://checkout.stripe.com/checkout.js" class="stripe-button"
       data-key="<%= Rails.configuration.stripe[:publishable_key] %>"


### PR DESCRIPTION
added logic that does, or does not ask for credit card details for a future appointment dependent on (1) whether we already have the details (2) Lawyer has a free consultation & whether they already had a valid consultation (> 0 seconds)